### PR TITLE
add /status (GET) endpoint for healthcheck

### DIFF
--- a/wembeddings/wembeddings_server.py
+++ b/wembeddings/wembeddings_server.py
@@ -79,6 +79,20 @@ class WEmbeddingsServer(socketserver.ThreadingTCPServer):
             else:
                 request.respond_error("No handler for the given URL '{}'".format(url.path), code=404)
 
+        def do_GET(request):
+            try:
+                request.path = request.path.encode("iso-8859-1").decode("utf-8")
+                url = urllib.parse.urlparse(request.path)
+            except:
+                return request.respond_error("Cannot parse request URL.")
+
+            if url.path == "/status":
+                request.respond("application/json")
+                request.wfile.write(bytes("""{"status": "UP"}""", "utf-8"))
+            # URL not found
+            else:
+                request.respond_error("No handler for the given URL '{}'".format(url.path), code=404)
+
     daemon_threads = False
 
     def __init__(self, port, dtype, wembeddings_lambda):


### PR DESCRIPTION
For deployment and automatic health-check/liveness checking (Kubernetes (k8s) is one system, which supports this, but there are others), it is beneficial to have a simple health-check/status endpoint, which can serve the purpose of just checking if the application server is still alive and responding.
For this purpose, I propose this simple health check. It's not ideal, but it should be good enough (the issue is mainly the general `except` block without specifying the exception, but there are multiple places with this problem already, so I think it's good for now and the `except` blocks can be fixed later in another PR/commit).